### PR TITLE
[cmath] Only use ISO math functions in avr-libm

### DIFF
--- a/include/bits/std_abs.h
+++ b/include/bits/std_abs.h
@@ -36,9 +36,6 @@
 
 #define _GLIBCXX_INCLUDE_NEXT_C_HEADERS
 #include_next <stdlib.h>
-#ifdef __CORRECT_ISO_CPP_MATH_H_PROTO
-# include_next <math.h>
-#endif
 #undef _GLIBCXX_INCLUDE_NEXT_C_HEADERS
 
 #undef abs
@@ -65,7 +62,6 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 // 2192. Validity and return type of std::abs(0u) is unclear
 // 2294. <cstdlib> should declare abs(double)
 
-#ifndef __CORRECT_ISO_CPP_MATH_H_PROTO
   inline _GLIBCXX_CONSTEXPR double
   abs(double __x)
   { return __builtin_fabs(__x); }
@@ -77,7 +73,6 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
   inline _GLIBCXX_CONSTEXPR long double
   abs(long double __x)
   { return __builtin_fabsl(__x); }
-#endif
 
 #if defined(__GLIBCXX_TYPE_INT_N_0)
   inline _GLIBCXX_CONSTEXPR __GLIBCXX_TYPE_INT_N_0

--- a/include/cmath
+++ b/include/cmath
@@ -74,6 +74,9 @@
 #undef tan
 #undef tanh
 
+// avr-libc does not provide float or long overloads of any math function!
+#define __CORRECT_ISO_CPP_MATH_H_PROTO 1
+
 extern "C++"
 {
 namespace std _GLIBCXX_VISIBILITY(default)


### PR DESCRIPTION
avr-libm does not provide float or long overloads of math functions, so linking against `__builtin_sinf` resolving to just `::sinf` will fail.

I discovered this when compiling the modm math unittests for avr, which uses `float` types and therefore calls `std::sin(float)`, which the stdlibc++ overloads to use `__builtin_sinf` instead of just forwarding everything to `__builtin_sin`.

avr-libm is not very consistent about what overloads it provides though, and I'm not sure if this is the right fix, but it makes the unittests link and pass.

```
 $ avr-nm path/to/avr-gcc/9.x.y/avr/lib/avr4/libm.a --defined-only # => output cleaned up
acos
asin
atan
atan2
cbrt
ceil
copysign
cos
cosh
exp
fdim
floor
fma
fmax
fmin
fmod
frexp
hypot
inverse
isfinite
isinf
isnan
ldexp
log
log10
lrint
lround
modf
modff
pow
round
signbit
sin
sinh
sqrt
sqrtf
square
tan
tanh
trunc
```

cc @chris-durand 
