### PR TITLE
match exception specification of op new(size_t)

### DIFF
--- a/examples/common/new.cpp
+++ b/examples/common/new.cpp
@@ -30,13 +30,13 @@ allocate(size_t size) _GLIBCXX_USE_NOEXCEPT
 }
 
 void *
-operator new(size_t size) _GLIBCXX_USE_NOEXCEPT
+operator new(size_t size) _GLIBCXX_THROW (std::bad_alloc)
 {
 	return allocate<true>(size);
 }
 
 void *
-operator new[](size_t size) _GLIBCXX_USE_NOEXCEPT
+operator new[](size_t size) _GLIBCXX_THROW (std::bad_alloc)
 {
 	return allocate<true>(size);
 }


### PR DESCRIPTION
Shall fix #2.

The exception specification of the `operator new(size_t)` should match the one of the previous declaration. The previous declaration is included from `../../include\new`: 
```
_GLIBCXX_THROW (std::bad_alloc)
```

Adding `_GLIBCXX_THROW (std::bad_alloc)` to the definition would be possible but is IMHO not a good idea for these reasons:

- `std::bad_alloc` is not declared
- `throw` is deprecated
- the definition does not throw anything

Removing the exception specification will compile fine for C++>=11. For C++<11 the code will not compile anyways as `std::bad_alloc` is not declared.