### PR TITLE
Use avr-objdump instead of avr-size in example Makefile.

### DIFF
--- a/examples/vector/Makefile
+++ b/examples/vector/Makefile
@@ -39,7 +39,7 @@ $(BUILD_DIR)/%.cc.o: %.cc
 	avr-g++ -c $(CXXFLAGS) -mmcu=$(MCU) $(INCLUDES) $< -o $@
 
 size: $(TARGET).elf
-	avr-size --mcu=$(MCU) -C $(TARGET).elf
+	avr-objdump -Pmem-usage $(TARGET).elf
 
 program: $(TARGET).hex
 	avrdude -p$(MCU) $(AVRDUDE_FLAGS) -c$(PROGRAMMER) -Uflash:w:$(TARGET).hex:a


### PR DESCRIPTION
Apparently the "improved" way to determine the memory usage is using `avr-objdump -Pmem-usage <path to elf>`.

See: https://www.avrfreaks.net/comment/2446681#comment-2446681

Output for the vector example:

```
...
avr-objdump -Pmem-usage ./build/vector-test.elf

./build/vector-test.elf:     file format elf32-avr
AVR Memory Usage
----------------
Device: atmega328p

Program:    3526 bytes (10.8% Full)
(.text + .data + .bootloader)

Data:         88 bytes (4.3% Full)
(.data + .bss + .noinit)
```

This does fix #5.