### PR TITLE
Enable _GLIBCXX_USE_C99_MATH_TR1 to provide more math functions in std

### DIFF
--- a/include/bits/c++config.h
+++ b/include/bits/c++config.h
@@ -1620,7 +1620,7 @@ namespace std
 
 /* Define if C99 functions or macros in <math.h> should be imported in
    <tr1/cmath> in namespace std::tr1. */
-//#define _GLIBCXX_USE_C99_MATH_TR1 1
+#define _GLIBCXX_USE_C99_MATH_TR1 1
 
 /* Define if C99 types in <stdint.h> should be imported in <tr1/cstdint> in
    namespace std::tr1. */


### PR DESCRIPTION
Provide all avr math.h math functions in std namespace. Use of some of C99 math functions in `cmath` enabled by this change outside of a constant expression will result in a linker error because avr-libm does not have an implementation.