### PR TITLE
Handle ISO C <cmath> fixes and add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ in 2020 modernized the port to include many modern C++20 features.
 - There are also a handful of source files located in the [src directory](./src). Some of these may potentially be needed.
 - For instance, when doing floating-point mathematical calculations with the `<cmath>` library, the file [`math.cc`](./src/math.cc) located [here](./src) needs to be added as a normal source file to your project.
 
-For example:
 
-Simply add the `-isystem` (or alternatively the `-I`) include path
+For straightforward header-only use, for example,
+simply add the `-isystem` (or alternatively the `-I`) include path
 to your particular location of `avr-libstdcpp/include` on the command line...
 
 ```sh
@@ -68,10 +68,10 @@ can be found in the [examples](./examples) folder.
 The include path of the headers needs to be added to the project settings in the normal way.
 Add also any of the necessary source files, as described in the section above.
 
-This is an advanced use of `avr-libstdcpp` in combination with MICROCHIP'sATMEL Studio
+This is an advanced use of `avr-libstdcpp` in combination with MICROCHIP's ATMEL Studio
 because the underlying GCC compiler used with ATMEL Studio also needs to be
-upgraded to a much more modern one than the GCC5 delivered in the standard installation
-of this studio.
+upgraded to a much more modern one than the `avr-gcc` 5
+delivered in the standard installation of this studio.
 
 An [informative thread](https://github.com/modm-io/avr-libstdcpp/issues/17#issuecomment-1098241768)
 provides a few more details on how to use `avr-libstdcpp` with MICROCHIP's ATMEL Studio.

--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@ The widths depend on the compiler command line options `-mdouble=32`
 `std::exp()` and the like will, therefore, have input and output
 widths according to these command line options.
 
+- **`<cmath>`:** In compiler versions of `avr-gcc` 11 and higher,
+slight discrepancies in the signatures of functions like
+`isnan()`, `isinf()`, etc. seem to be in the process of being corrected.
+Future patches of math function signatures in `<cmath>`
+may be needed as the `<math.h>` header continues to evolve.
+
 ## C++20 `constexpr` support
 
 The following is a rather advanced, highly useful topic.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ in 2020 modernized the port to include many modern C++20 features.
 
 ## Using the library
 
-Add the `avr-libstdcpp/include` path to the standard `-I`
-include path(s) of the compiler on the command line.
-Upon doing this, include standard library headers in the usual way.
+- Add the `avr-libstdcpp/include` path to the standard `-I` include path(s) of the compiler on the command line.
+- Upon doing this, include standard library headers in the usual way (i.e., `#include <algorithm>`,  `#include <array>`,  `#include <cstdint>`, etc.).
+- There are also a handful of source files located in the [src directory](./src). Some of these may potentially be needed.
+- For instance, when doing floating-point mathematical calculations with the `<cmath>` library, the file [`math.cc`](./src/math.cc) located [here](./src) needs to be added as a normal source file to your project.
 
 For example:
 
@@ -61,6 +62,20 @@ int main()
 Additional straightforward code samples exercising standard library usage
 can be found in the [examples](./examples) folder.
 
+## Using the library with MICROCHIP's ATMEL Studio
+
+`avr-libstdcpp` can be successfully used with MICROCHIP's ATMEL Studio.
+The include path of the headers needs to be added to the project settings in the normal way.
+Add also any of the necessary source files, as described in the section above.
+
+This is an advanced use of `avr-libstdcpp` in combination with MICROCHIP'sATMEL Studio
+because the underlying GCC compiler used with ATMEL Studio also needs to be
+upgraded to a much more modern one than the GCC5 delivered in the standard installation
+of this studio.
+
+An [informative thread](https://github.com/modm-io/avr-libstdcpp/issues/17#issuecomment-1098241768)
+provides a few more details on how to use `avr-libstdcpp` with MICROCHIP's ATMEL Studio.
+
 ## Guidance for tiny bare-metal systems
 
 ### Very helpful go-to libraries
@@ -85,7 +100,7 @@ and their main uses includes, but is not limited to,:
 
 - `<array>` for containers having known, fixed size.
 - `<algorithm>` for standard algorithms such as sorting, minimax, sequential operations, etc.
-- `<cmath>` for projects requiring floating-point mathematical functions such as `std::sin()`, `std::exp()`, `std::frexp()` and many more.
+- `<cmath>` for projects requiring floating-point mathematical functions such as `std::sin()`, `std::exp()`, `std::frexp()` and many more. For some mathematical uses, it might be necessary to include [`math.cc`](./src/math.cc) in your project. This source file is located [here](./src).
 - `<cstdint>` which defines integral types having specified widths residing within `namespace std` like `std::uint8_t`.
 - `<limits>` offering compile-time query of numeric limits of built-in types.
 - `<numeric>` featuring a collection of useful numeric algorithms such as `std::accumulate()`, etc.
@@ -223,7 +238,7 @@ and their directly relevant code sequences have been removed.
 Simple mechanisms such as those found in `<cassert>`
 and `<cerrno>`, however, remain mostly available.
 
-- **`<atomic>`:** Even though the intended compilers are build with no threading,
+- **`<atomic>`:** Even though the intended compilers are built with no threading,
 the `<atomic>` library and its use as a dependency has
 been removed. This means that atomic functions and
 atomic store/load functions are not available. So if you are sharing

--- a/examples/cmath/Makefile
+++ b/examples/cmath/Makefile
@@ -25,7 +25,7 @@ WARNFLAGS+=-Wno-volatile
 endif
 
 CXXFLAGS=-std=$(STD) -O2 $(WARNFLAGS) -fno-exceptions -fno-rtti -fno-unwind-tables -fno-threadsafe-statics -Wshadow -Wcast-qual -Wpointer-arith -Wundef
-LDFLAGS=
+LDFLAGS=-lm
 
 TARGET=$(BUILD_DIR)/$(NAME)
 

--- a/examples/cmath/Makefile
+++ b/examples/cmath/Makefile
@@ -1,0 +1,59 @@
+﻿NAME=cmath-test
+MCU=atmega328p
+
+ifeq ($(STD),)
+STD=c++17
+endif
+
+BUILD_DIR=./build
+LIB_DIR=../..
+
+ifeq ($(INC),)
+INCLUDES= -I$(LIB_DIR)/include
+else
+INCLUDES= -I$(INC)
+endif
+
+SOURCES=$(LIB_DIR)/examples/cmath/cmath.cpp
+VPATH=.:$(LIB_DIR)/examples/cmath
+OBJECTS=$(addprefix $(BUILD_DIR)/,$(notdir $(SOURCES:%=%.o)))
+
+WARNFLAGS=-Wall -Wextra -pedantic
+
+ifeq ($(STD),c++20)
+WARNFLAGS+=-Wno-volatile
+endif
+
+CXXFLAGS=-std=$(STD) -O2 $(WARNFLAGS) -fno-exceptions -fno-rtti -fno-unwind-tables -fno-threadsafe-statics -Wshadow -Wcast-qual -Wpointer-arith -Wundef
+LDFLAGS=
+
+TARGET=$(BUILD_DIR)/$(NAME)
+
+all: hex size
+
+hex: $(TARGET).hex
+
+$(TARGET).hex: $(TARGET).elf
+	avr-objcopy -O ihex -j .data -j .text $(TARGET).elf $(TARGET).hex
+
+$(TARGET).elf: $(OBJECTS)
+	avr-g++ $(LDFLAGS) -mmcu=$(MCU) $(OBJECTS) -o $(TARGET).elf
+
+$(BUILD_DIR)/%.cpp.o: %.cpp
+	@mkdir -p $(BUILD_DIR)
+	avr-g++ -c $(CXXFLAGS) -mmcu=$(MCU) $(INCLUDES) $< -o $@
+
+$(BUILD_DIR)/%.cc.o: %.cc
+	@mkdir -p $(BUILD_DIR)
+	avr-g++ -c $(CXXFLAGS) -mmcu=$(MCU) $(INCLUDES) $< -o $@
+
+size: $(TARGET).elf
+	avr-objdump -Pmem-usage $(TARGET).elf
+
+program: $(TARGET).hex
+	avrdude -p$(MCU) $(AVRDUDE_FLAGS) -c$(PROGRAMMER) -Uflash:w:$(TARGET).hex:a
+
+clean:
+	rm -rf $(BUILD_DIR)/*.o
+	rm -rf $(BUILD_DIR)/*.elf
+	rm -rf $(BUILD_DIR)/*.hex

--- a/examples/cmath/cmath.cpp
+++ b/examples/cmath/cmath.cpp
@@ -26,8 +26,7 @@ auto integral
 	RealFunctionType real_function
 ) noexcept -> RealValueType
 {
-	using real_value_type    = RealValueType;
-	using real_function_type = RealFunctionType;
+	using real_value_type = RealValueType;
 
 	std::uint_fast32_t n2(1);
 

--- a/examples/cmath/cmath.cpp
+++ b/examples/cmath/cmath.cpp
@@ -1,0 +1,152 @@
+﻿/*
+ * Copyright (c) 2022, Christopher Kormanyos
+ *
+ * This file is part of the modm project.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+// ----------------------------------------------------------------------------
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace local {
+
+namespace detail {
+
+template<typename real_value_type, typename real_function_type>
+auto integral
+(
+	const real_value_type& a,
+	const real_value_type& b,
+	const real_value_type& tol,
+	real_function_type real_function
+) noexcept -> real_value_type
+{
+	std::uint_fast32_t n2(1);
+
+	real_value_type step = ((b - a) / 2U);
+	real_value_type result = (real_function(a) + real_function(b)) * step;
+
+	const std::uint_fast8_t k_max = UINT8_C(32);
+
+	for(std::uint_fast8_t k = UINT8_C(0); k < k_max; ++k)
+	{
+		real_value_type sum(0);
+
+		for(std::uint_fast32_t j(0U); j < n2; ++j)
+		{
+			const std::uint_fast32_t two_j_plus_one = (j * UINT32_C(2)) + UINT32_C(1);
+
+			sum += real_function(a + real_value_type(step * real_value_type(two_j_plus_one)));
+		}
+
+		const real_value_type tmp = result;
+
+		result = (result / 2U) + (step * sum);
+
+		using std::fabs;
+
+		const real_value_type ratio = fabs(tmp / result);
+
+		const real_value_type delta = fabs(ratio - 1U);
+
+		if((k > UINT8_C(1)) && (delta < tol))
+		{
+			break;
+		}
+
+		n2 *= 2U;
+
+		step /= 2U;
+	}
+
+	return result;
+}
+
+template<typename FloatingPointType>
+auto is_close_fraction
+(
+	const FloatingPointType a,
+	const FloatingPointType b,
+	const FloatingPointType tol = FloatingPointType(std::numeric_limits<FloatingPointType>::epsilon() * NumericType(100))
+) noexcept -> bool
+{
+	using std::fabs;
+
+	const FloatingPointType ratio     = fabs(FloatingPointType((FloatingPointType(1) * a) / b));
+
+	const FloatingPointType closeness = fabs(FloatingPointType(1 - ratio));
+
+	return (closeness < tol);
+}
+
+// N[Pi, 51]
+// 3.14159265358979323846264338327950288419716939937511
+template<typename FloatingPointType> constexpr  FloatingPointType pi_v;
+template<>                           constexpr float              pi_v<float>       = 3.14159265358979323846264338327950288419716939937511F;
+template<>                           constexpr double             pi_v<double>      = 3.14159265358979323846264338327950288419716939937511;
+template<>                           constexpr long double        pi_v<long double> = 3.14159265358979323846264338327950288419716939937511L;
+
+} // namespace detail
+
+template<typename FloatingPointType>
+auto cyl_bessel_j(const std::uint_fast8_t n, const FloatingPointType& x) noexcept -> FloatingPointType
+{
+	using local_float_type = FloatingPointType;
+
+	constexpr local_float_type epsilon = std::numeric_limits<local_float_type>::epsilon();
+
+	using std::cos;
+	using std::sin;
+	using std::sqrt;
+
+	const auto tol = sqrt(epsilon);
+
+	const auto integration_result =
+	detail::integral
+	(
+		static_cast<local_float_type>(0),
+		detail::pi_v<local_float_type>,
+		tol,
+		[&x, &n](const local_float_type& t) noexcept -> local_float_type
+		{
+			return cos(x * sin(t) - (t * static_cast<local_float_type>(n)));
+		});
+
+	const auto jn = static_cast<local_float_type>(integration_result / detail::pi_v<local_float_type>);
+
+	return jn;
+}
+
+} // namespace local
+
+auto main() -> int
+{
+	using my_float_type = long double;
+
+	static_assert((std::numeric_limits<my_float_type>::digits >= 24), "Error: Incorrect my_float_type type definition");
+
+	constexpr my_float_type my_tol =
+		static_cast<my_float_type>
+		(
+			std::numeric_limits<my_float_type>::epsilon() * static_cast<my_float_type>(100.0L)
+		);
+
+	// Compute y = cyl_bessel_j(2, 1.23) = 0.16636938378681407351267852431513159437103348245333
+	// N[BesselJ[2, 123/100], 50]
+	const my_float_type j2 = local::cyl_bessel_j(UINT8_C(2), static_cast<my_float_type>(1.23L));
+
+	const bool result_is_ok =
+		local::detail::is_close_fraction
+		(
+			static_cast<my_float_type>(0.1663693837868140735126785243L),
+			j2,
+			my_tol
+		);
+
+	return (result_is_ok ? 0 : -1);
+}

--- a/examples/cmath/cmath.cpp
+++ b/examples/cmath/cmath.cpp
@@ -17,15 +17,18 @@ namespace local {
 
 namespace detail {
 
-template<typename real_value_type, typename real_function_type>
+template<typename RealValueType, typename RealFunctionType>
 auto integral
 (
-	const real_value_type& a,
-	const real_value_type& b,
-	const real_value_type& tol,
-	real_function_type real_function
-) noexcept -> real_value_type
+	const RealValueType& a,
+	const RealValueType& b,
+	const RealValueType& tol,
+	RealFunctionType real_function
+) noexcept -> RealValueType
 {
+	using real_value_type    = RealValueType;
+	using real_function_type = RealFunctionType;
+
 	std::uint_fast32_t n2(1);
 
 	real_value_type step = ((b - a) / 2U);
@@ -75,11 +78,13 @@ auto is_close_fraction
 	const FloatingPointType tol = FloatingPointType(std::numeric_limits<FloatingPointType>::epsilon() * FloatingPointType(100))
 ) noexcept -> bool
 {
+	using floating_point_type = FloatingPointType;
+
 	using std::fabs;
 
-	const FloatingPointType ratio     = fabs(FloatingPointType((FloatingPointType(1) * a) / b));
+	const floating_point_type ratio     = fabs(floating_point_type((floating_point_type(1) * a) / b));
 
-	const FloatingPointType closeness = fabs(FloatingPointType(1 - ratio));
+	const floating_point_type closeness = fabs(floating_point_type(1 - ratio));
 
 	return (closeness < tol);
 }
@@ -96,9 +101,9 @@ template<>                           constexpr long double        pi_v<long doub
 template<typename FloatingPointType>
 auto cyl_bessel_j(const std::uint_fast8_t n, const FloatingPointType& x) noexcept -> FloatingPointType
 {
-	using local_float_type = FloatingPointType;
+	using floating_point_type = FloatingPointType;
 
-	constexpr local_float_type epsilon = std::numeric_limits<local_float_type>::epsilon();
+	constexpr floating_point_type epsilon = std::numeric_limits<floating_point_type>::epsilon();
 
 	using std::cos;
 	using std::sin;
@@ -109,15 +114,15 @@ auto cyl_bessel_j(const std::uint_fast8_t n, const FloatingPointType& x) noexcep
 	const auto integration_result =
 	detail::integral
 	(
-		static_cast<local_float_type>(0),
-		detail::pi_v<local_float_type>,
+		static_cast<floating_point_type>(0),
+		detail::pi_v<floating_point_type>,
 		tol,
-		[&x, &n](const local_float_type& t) noexcept -> local_float_type
+		[&x, &n](const floating_point_type& t) noexcept -> floating_point_type
 		{
-			return cos(x * sin(t) - (t * static_cast<local_float_type>(n)));
+			return cos(x * sin(t) - (t * static_cast<floating_point_type>(n)));
 		});
 
-	const auto jn = static_cast<local_float_type>(integration_result / detail::pi_v<local_float_type>);
+	const auto jn = static_cast<floating_point_type>(integration_result / detail::pi_v<floating_point_type>);
 
 	return jn;
 }

--- a/examples/cmath/cmath.cpp
+++ b/examples/cmath/cmath.cpp
@@ -72,7 +72,7 @@ auto is_close_fraction
 (
 	const FloatingPointType a,
 	const FloatingPointType b,
-	const FloatingPointType tol = FloatingPointType(std::numeric_limits<FloatingPointType>::epsilon() * NumericType(100))
+	const FloatingPointType tol = FloatingPointType(std::numeric_limits<FloatingPointType>::epsilon() * FloatingPointType(100))
 ) noexcept -> bool
 {
 	using std::fabs;

--- a/include/cmath
+++ b/include/cmath
@@ -77,10 +77,6 @@
 // Fix float math functions defined as macros in avr libc
 #ifdef __AVR__
 
-#if !defined(MODM_CMATH_GCC_VERSION)
-#define MODM_CMATH_GCC_VERSION ((__GNUC__ * 10000L) + (__GNUC_MINOR__ * 100L) + __GNUC_PATCHLEVEL__)
-#endif
-
 #undef cosf
 #undef sinf
 #undef tanf
@@ -143,15 +139,9 @@ extern "C"
   float logf(float x);
   float log10f(float x);
   float powf(float x, float y);
-  #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
-  bool isnanf(float x);
-  bool isinff(float x);
-  bool isfinitef(float x);
-  #else
   int isnanf(float x);
   int isinff(float x);
   int isfinitef(float x);
-  #endif
   float copysignf(float x, float y);
   int signbitf(float x);
   float fdimf(float x, float y);

--- a/include/cmath
+++ b/include/cmath
@@ -139,9 +139,9 @@ extern "C"
   float logf(float x);
   float log10f(float x);
   float powf(float x, float y);
-  bool isnanf(float x);
-  bool isinff(float x);
-  bool isfinitef(float x);
+  int isnanf(float x);
+  int isinff(float x);
+  int isfinitef(float x);
   float copysignf(float x, float y);
   int signbitf(float x);
   float fdimf(float x, float y);

--- a/include/cmath
+++ b/include/cmath
@@ -49,8 +49,6 @@
 #ifndef _GLIBCXX_CMATH
 #define _GLIBCXX_CMATH 1
 
-#define MODM_CMATH_GCC_VERSION ((__GNUC__ * 10000L) + (__GNUC_MINOR__ * 100L) + __GNUC_PATCHLEVEL__)
-
 // Get rid of those macros defined in <math.h> in lieu of real functions.
 #undef div
 #undef acos
@@ -78,6 +76,10 @@
 
 // Fix float math functions defined as macros in avr libc
 #ifdef __AVR__
+
+#if !defined(MODM_CMATH_GCC_VERSION)
+#define MODM_CMATH_GCC_VERSION ((__GNUC__ * 10000L) + (__GNUC_MINOR__ * 100L) + __GNUC_PATCHLEVEL__)
+#endif
 
 #undef cosf
 #undef sinf

--- a/include/cmath
+++ b/include/cmath
@@ -49,6 +49,8 @@
 #ifndef _GLIBCXX_CMATH
 #define _GLIBCXX_CMATH 1
 
+#define MODM_CMATH_GCC_VERSION ((__GNUC__ * 10000L) + (__GNUC_MINOR__ * 100L) + __GNUC_PATCHLEVEL__)
+
 // Get rid of those macros defined in <math.h> in lieu of real functions.
 #undef div
 #undef acos
@@ -139,9 +141,15 @@ extern "C"
   float logf(float x);
   float log10f(float x);
   float powf(float x, float y);
+  #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
+  bool isnanf(float x);
+  bool isinff(float x);
+  bool isfinitef(float x);
+  #else
   int isnanf(float x);
   int isinff(float x);
   int isfinitef(float x);
+  #endif
   float copysignf(float x, float y);
   int signbitf(float x);
   float fdimf(float x, float y);

--- a/src/math.cc
+++ b/src/math.cc
@@ -11,10 +11,7 @@
 #include <cmath>
 
 #ifdef __AVR__
-
-#if !defined(MODM_CMATH_GCC_VERSION)
-#define MODM_CMATH_GCC_VERSION ((__GNUC__ * 10000L) + (__GNUC_MINOR__ * 100L) + __GNUC_PATCHLEVEL__)
-#endif
+#include <avr/version.h>
 
 extern "C"
 {
@@ -33,7 +30,7 @@ extern "C"
     return ::tan(x);
   }
 
-  #if (MODM_CMATH_GCC_VERSION < 110300L)
+  #if defined(__AVR_LIBC_VERSION__) && (__AVR_LIBC_VERSION__ < 20100UL)
   float fabsf(float x)
   {
     return ::fabs(x);
@@ -145,7 +142,7 @@ extern "C"
     return ::isinf(x);
   }
 
-  #if (MODM_CMATH_GCC_VERSION < 110300L)
+  #if defined(__AVR_LIBC_VERSION__) && (__AVR_LIBC_VERSION__ < 20100UL)
   int isfinitef(float x)
   {
     return ::isfinite(x);

--- a/src/math.cc
+++ b/src/math.cc
@@ -12,6 +12,10 @@
 
 #ifdef __AVR__
 
+#if !defined(MODM_CMATH_GCC_VERSION)
+#define MODM_CMATH_GCC_VERSION ((__GNUC__ * 10000L) + (__GNUC_MINOR__ * 100L) + __GNUC_PATCHLEVEL__)
+#endif
+
 extern "C"
 {
   float cosf(float x)
@@ -129,17 +133,29 @@ extern "C"
     return ::pow(x, y);
   }
 
+  #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
   bool isnanf(float x)
+  #else
+  int isnanf(float x)
+  #endif
   {
     return ::isnan(x);
   }
 
+  #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
   bool isinff(float x)
+  #else
+  int isinff(float x)
+  #endif
   {
     return ::isinf(x);
   }
 
+  #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
   bool isfinitef(float x)
+  #else
+  int isfinitef(float x)
+  #endif
   {
     return ::isfinite(x);
   }

--- a/src/math.cc
+++ b/src/math.cc
@@ -33,10 +33,12 @@ extern "C"
     return ::tan(x);
   }
 
+  #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
   float fabsf(float x)
   {
     return ::fabs(x);
   }
+  #endif
 
   float fmodf(float x, float y)
   {
@@ -153,17 +155,17 @@ extern "C"
 
   #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
   bool isfinitef(float x)
-  #else
-  int isfinitef(float x)
-  #endif
   {
     return ::isfinite(x);
   }
+  #endif
 
+  #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
   float copysignf(float x, float y)
   {
     return ::copysign(x, y);
   }
+  #endif
 
   int signbitf(float x)
   {

--- a/src/math.cc
+++ b/src/math.cc
@@ -33,7 +33,7 @@ extern "C"
     return ::tan(x);
   }
 
-  #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
+  #if (MODM_CMATH_GCC_VERSION < 110300L)
   float fabsf(float x)
   {
     return ::fabs(x);
@@ -145,7 +145,7 @@ extern "C"
     return ::isinf(x);
   }
 
-  #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
+  #if (MODM_CMATH_GCC_VERSION < 110300L)
   int isfinitef(float x)
   {
     return ::isfinite(x);

--- a/src/math.cc
+++ b/src/math.cc
@@ -135,32 +135,22 @@ extern "C"
     return ::pow(x, y);
   }
 
-  #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
-  bool isnanf(float x)
-  #else
   int isnanf(float x)
-  #endif
   {
     return ::isnan(x);
   }
 
-  #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
-  bool isinff(float x)
-  #else
   int isinff(float x)
-  #endif
   {
     return ::isinf(x);
   }
 
   #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
-  bool isfinitef(float x)
+  int isfinitef(float x)
   {
     return ::isfinite(x);
   }
-  #endif
 
-  #if defined(MODM_CMATH_GCC_VERSION) && (MODM_CMATH_GCC_VERSION < 110300L)
   float copysignf(float x, float y)
   {
     return ::copysign(x, y);


### PR DESCRIPTION
This is the first attempt to correct ISO C signatures (first mentioned in #17) and specifically treated in #18