### PR TITLE
Disable all floating point functions for libc 2.1.0 on GCC12

### DIFF
--- a/src/math.cc
+++ b/src/math.cc
@@ -15,6 +15,7 @@
 
 extern "C"
 {
+  #if defined(__AVR_LIBC_VERSION__) && (__AVR_LIBC_VERSION__ < 20100UL)
   float cosf(float x)
   {
     return ::cos(x);
@@ -30,12 +31,10 @@ extern "C"
     return ::tan(x);
   }
 
-  #if defined(__AVR_LIBC_VERSION__) && (__AVR_LIBC_VERSION__ < 20100UL)
   float fabsf(float x)
   {
     return ::fabs(x);
   }
-  #endif
 
   float fmodf(float x, float y)
   {
@@ -142,7 +141,6 @@ extern "C"
     return ::isinf(x);
   }
 
-  #if defined(__AVR_LIBC_VERSION__) && (__AVR_LIBC_VERSION__ < 20100UL)
   int isfinitef(float x)
   {
     return ::isfinite(x);
@@ -152,7 +150,6 @@ extern "C"
   {
     return ::copysign(x, y);
   }
-  #endif
 
   int signbitf(float x)
   {
@@ -198,6 +195,7 @@ extern "C"
   {
     return ::lrint(x);
   }
+  #endif
 } // extern "C"
 
 #endif // __AVR__


### PR DESCRIPTION
modm is switching to [avr-gcc 12.2.0](https://github.com/modm-io/modm/pull/940) but the compiler now generates infinite loops when calling `sinf` or `sin`. There is no warning or error emitted, so this is a very dangerous bug.

The [libc 2.1.0 has proper function prototypes for the floating point functions](https://github.com/avrdudes/avr-libc/commit/e08bbd25e260804090e3e55e40bbcac3dc8f4abd), so we don't need to specify them here anymore.

I'm still not sure why this didn't occur with avr-gcc 11.2 or avr-gcc 10.3.

cc @ckormanyos @chris-durand 