### PR TITLE
Fix compilation of type_traits with gcc 13

### DIFF
--- a/include/type_traits
+++ b/include/type_traits
@@ -1453,6 +1453,21 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
     using __is_array_convertible
       = is_convertible<_FromElementType(*)[], _ToElementType(*)[]>;
 
+#if __cplusplus >= 202002L
+#define __cpp_lib_is_nothrow_convertible 201806L
+
+#if __has_builtin(__is_nothrow_convertible)
+  /// is_nothrow_convertible_v
+  template<typename _From, typename _To>
+    inline constexpr bool is_nothrow_convertible_v
+      = __is_nothrow_convertible(_From, _To);
+
+  /// is_nothrow_convertible
+  template<typename _From, typename _To>
+    struct is_nothrow_convertible
+    : public bool_constant<is_nothrow_convertible_v<_From, _To>>
+    { };
+#else
   template<typename _From, typename _To,
            bool = __or_<is_void<_From>, is_function<_To>,
                         is_array<_To>>::value>
@@ -1482,14 +1497,6 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
     };
 #pragma GCC diagnostic pop
 
-  // is_nothrow_convertible for C++11
-  template<typename _From, typename _To>
-    struct __is_nothrow_convertible
-    : public __is_nt_convertible_helper<_From, _To>::type
-    { };
-
-#if __cplusplus > 201703L
-#define __cpp_lib_is_nothrow_convertible 201806L
   /// is_nothrow_convertible
   template<typename _From, typename _To>
     struct is_nothrow_convertible
@@ -1500,6 +1507,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
   template<typename _From, typename _To>
     inline constexpr bool is_nothrow_convertible_v
       = is_nothrow_convertible<_From, _To>::value;
+#endif
 #endif // C++2a
 
   // Const-volatile modifications.
@@ -2984,22 +2992,29 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	"_Fn must be a complete class or an unbounded array");
     };
 
-  template<typename _Result, typename _Ret, typename = void>
-    struct __is_nt_invocable_impl : false_type { };
-
+  /// @cond undocumented
+  // This checks that the INVOKE<R> expression is well-formed and that the
+  // conversion to R does not throw. It does *not* check whether the INVOKE
+  // expression itself can throw. That is done by __call_is_nothrow_ instead.
   template<typename _Result, typename _Ret>
-    struct __is_nt_invocable_impl<_Result, _Ret,
-				  __void_t<typename _Result::type>>
-    : __or_<is_void<_Ret>,
-	    __is_nothrow_convertible<typename _Result::type, _Ret>>
-    { };
+    using __is_nt_invocable_impl
+      = typename __is_invocable_impl<_Result, _Ret>::__nothrow_conv;
+  /// @endcond
 
   /// std::is_nothrow_invocable_r
   template<typename _Ret, typename _Fn, typename... _ArgTypes>
     struct is_nothrow_invocable_r
     : __and_<__is_nt_invocable_impl<__invoke_result<_Fn, _ArgTypes...>, _Ret>,
              __call_is_nothrow_<_Fn, _ArgTypes...>>::type
-    { };
+    {
+      static_assert(std::__is_complete_or_unbounded(__type_identity<_Fn>{}),
+	"_Fn must be a complete class or an unbounded array");
+      static_assert((std::__is_complete_or_unbounded(
+	__type_identity<_ArgTypes>{}) && ...),
+	"each argument type must be a complete class or an unbounded array");
+      static_assert(std::__is_complete_or_unbounded(__type_identity<_Ret>{}),
+	"_Ret must be a complete class or an unbounded array");
+    };
 
   /// std::is_invocable_v
   template<typename _Fn, typename... _Args>


### PR DESCRIPTION
Add handling for new built-in `__is_nothrow_convertible` from current libstdc++. The code has been copied from the current libstdc++ release.
This should fix #27.