### PR TITLE
Fix naming issue

### DIFF
--- a/include/bits/unique_ptr.h
+++ b/include/bits/unique_ptr.h
@@ -482,13 +482,13 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
       __uniq_ptr_data<_Tp, _Dp> _M_t;
 
       template<typename _Up>
-	using __remove_cv = typename remove_cv<_Up>::type;
+	using __remove_cv_t = typename remove_cv<_Up>::type;
 
       // like is_base_of<_Tp, _Up> but false if unqualified types are the same
       template<typename _Up>
 	using __is_derived_Tp
 	  = __and_< is_base_of<_Tp, _Up>,
-		    __not_<is_same<__remove_cv<_Tp>, __remove_cv<_Up>>> >;
+		    __not_<is_same<__remove_cv_t<_Tp>, __remove_cv_t<_Up>>> >;
 
     public:
       using pointer	  = typename __uniq_ptr_impl<_Tp, _Dp>::pointer;


### PR DESCRIPTION
Hi everyone! I hope I am not bothering you guys, but I played around coroutines on AVR attiny85 and I needed a stdlibc++. This is a very nice library you made, but I have trouble compiling it on my GCC 13.1 for AVR. With this small fix everything works so I though that you might like these changes. It's not much I know :D . Anyway, if you would like me to change it in a different way let me know.