### PR TITLE
cmath: Restore definitions of std::fpclassify

### DIFF
--- a/include/cmath
+++ b/include/cmath
@@ -611,7 +611,48 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 #undef islessgreater
 #undef isunordered
 
+#if !defined(FP_NAN)
+#define FP_NAN         0
+#endif
+#if !defined(FP_INFINITE)
+#define FP_INFINITE    1
+#endif
+#if !defined(FP_ZERO)
+#define FP_ZERO        2
+#endif
+#if !defined(FP_SUBNORMAL)
+#define FP_SUBNORMAL   3
+#endif
+#if !defined(FP_NORMAL)
+#define FP_NORMAL      4
+#endif
+
 #if __cplusplus >= 201103L
+
+#ifndef __CORRECT_ISO_CPP11_MATH_H_PROTO_FP
+  constexpr int
+  fpclassify(float __x)
+  { return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL,
+                               FP_SUBNORMAL, FP_ZERO, __x); }
+
+  constexpr int
+  fpclassify(double __x)
+  { return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL,
+                               FP_SUBNORMAL, FP_ZERO, __x); }
+
+  constexpr int
+  fpclassify(long double __x)
+  { return __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL,
+                               FP_SUBNORMAL, FP_ZERO, __x); }
+#endif
+
+#ifndef __CORRECT_ISO_CPP11_MATH_H_PROTO_INT
+  template<typename _Tp>
+    constexpr typename __gnu_cxx::__enable_if<__is_integer<_Tp>::__value,
+                                              int>::__type
+    fpclassify(_Tp __x)
+    { return __x != 0 ? FP_NORMAL : FP_ZERO; }
+#endif
 
 #ifndef __CORRECT_ISO_CPP11_MATH_H_PROTO_FP
   constexpr bool


### PR DESCRIPTION
This partially reverts 5a4c53d1b2d9468286e99b180492682fbf12c6f7 and adds the constants needed for it to work.

Fixes: #40